### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/go-backend/cmd/main.go
+++ b/go-backend/cmd/main.go
@@ -108,9 +108,8 @@ func generateSummary(text string) (*SummarizationResponse, error) {
 		log.Fatal("GEMINI_API_KEY is not set. Please set it in .env or as an environment variable.")
 	}
 
-	// Mask the API key in logs
-	maskedApiKey := apiKey[:5] + "..." + apiKey[len(apiKey)-5:]
-	log.Printf("Using Gemini API Key (masked): %s", maskedApiKey)
+	// Log a generic message indicating the use of the API key
+	log.Println("Using Gemini API Key")
 
 	// Create Gemini client
 	client, err := genai.NewClient(ctx, option.WithAPIKey(apiKey))


### PR DESCRIPTION
Potential fix for [https://github.com/Gravity-Blog/gentle-story-summ/security/code-scanning/1](https://github.com/Gravity-Blog/gentle-story-summ/security/code-scanning/1)

To fix the problem, we should avoid logging the API key altogether, even in a masked form. Instead, we can log a generic message indicating that the API key is being used without revealing any part of it. This approach ensures that no sensitive information is exposed in the logs.

- Remove the line that logs the masked API key.
- Replace it with a generic log message that does not include any sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
